### PR TITLE
chore: add ceph 18 reef to versions list

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 .git/
 .github/
+.editorconfig
+.env
 LICENSE
 README.md

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-CONTAINER_REGISTRY=koorinc
-CONTAINER_REPO=koor-ceph-container
+CONTAINER_REGISTRY=docker.io
+CONTAINER_REPO=koorinc/koor-ceph-container

--- a/.github/workflows/docker-image-rebuild.yml
+++ b/.github/workflows/docker-image-rebuild.yml
@@ -5,6 +5,9 @@ on:
     # Runs "At 11:45 every day" (see https://crontab.guru)
     - cron: '45 11 * * *'
 
+  # Allow running rebuilds manually
+  workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -33,4 +33,3 @@ jobs:
         disable_matcher: false
         additional_files: build/reset build/sed-in-place
         format: gcc
-        

--- a/README.md
+++ b/README.md
@@ -9,12 +9,18 @@ Added functionality/ support for:
 * **Ceph FS Top Utility**: Used to provide extra CephFS metrics for monitoring in
 realtime. For more details, please refer: https://docs.ceph.com/en/quincy/cephfs/cephfs-top/
 
+## Ceph Versions
+
+We only rebuild the last 3 Ceph versions images as they are updated.
+
+For a list of the Ceph versions, see [`VERSIONS` file](/VERSIONS).
+
 ## Find koor-ceph-container image:
 
 The koor-ceph-container is hosted on [Koor's Docker Hub registry](https://hub.docker.com/repository/docker/koorinc/) and can be pulled using:
 
 ```console
-docker pull koorinc/koor-ceph-container:$VERSION_TAG
+docker pull docker.io/koorinc/koor-ceph-container:$VERSION_TAG
 ```
 
 Version tags can be found on [Koor's Docker Hub registry](https://hub.docker.com/repository/docker/koorinc/koor-ceph-container/tags?page=1&ordering=last_updated)
@@ -35,7 +41,7 @@ rebuilds them with dependencies and configurations needed for additional feature
 support using `src/Dockerfile` tagged as:
 
 ```console
-koorinc/koor-ceph-container:$RELEASE_VERSION
+docker.io/koorinc/koor-ceph-container:$RELEASE_VERSION
 ```
 
 The packaged images are based of CentOS. The rebuild image is then pushed to

--- a/VERSIONS
+++ b/VERSIONS
@@ -5,3 +5,5 @@
 v16
 # Ceph Quincy
 v17
+# Ceph Reef
+v18


### PR DESCRIPTION
This also updates the README with the info where the Ceph versions which we are actively rebuilding, can be found.

After this PR has been merged we can re-enable the Ceph image rebuild GitHub workflow.